### PR TITLE
ci: disable building with dependabot to keep travis credits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ rust: stable
 
 cache: cargo
 
+branches:
+  except:
+    - /^dependabot\/.*/
+
 env:
   global:
     - RUST_LOG=info


### PR DESCRIPTION
Signed-off-by: Jérémie Drouet <jeremie.drouet@gmail.com>